### PR TITLE
Add count as module var to enable creation toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Function source code is built locally using this Docker image https://github.com
 
 ### Optional arguments
 
+- `count` - Whether to create a lambda function or not at all (defaults to _1_)
 - `description` - lambda function description
 - `source_code_path` - path to function's source code to manage deployment (defaults to _""_)
 - `timeout` - function execution time in seconds after which Lambda terminates the function (defaults to _10_)
@@ -102,4 +103,3 @@ module "lambda" {
  - `last_modified` - the date this resource was last modified
  - `source_code_hash` - base64-encoded representation of raw SHA-256 sum of the zip file, provided either via filename or s3_* parameters
  - `source_code_size` - the size in bytes of the function .zip file
-

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # non-VPC Lambda
 
 resource "aws_lambda_function" "function" {
-  count            = "${length(var.subnet_ids) == 0 && length(var.env_variables) > 0 ? 1 : 0}"
+  count            = "${var.count == 1 && length(var.subnet_ids) == 0 && length(var.env_variables) > 0 ? 1 : 0}"
   function_name    = "${var.function_name}"
   description      = "${var.description}"
   role             = "${aws_iam_role.lambda.arn}"
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "function" {
 # VPC Lambda
 
 resource "aws_lambda_function" "function_vpc" {
-  count            = "${length(var.subnet_ids) != 0 && length(var.env_variables) > 0 ? 1 : 0}"
+  count            = "${var.count == 1 && length(var.subnet_ids) != 0 && length(var.env_variables) > 0 ? 1 : 0}"
   function_name    = "${var.function_name}"
   description      = "${var.description}"
   role             = "${aws_iam_role.lambda.arn}"
@@ -56,7 +56,7 @@ resource "aws_lambda_function" "function_vpc" {
 # non-VPC Lambda / empty environment
 
 resource "aws_lambda_function" "function_noenv" {
-  count            = "${length(var.subnet_ids) == 0 && length(var.env_variables) == 0 ? 1 : 0}"
+  count            = "${var.count == 1 && length(var.subnet_ids) == 0 && length(var.env_variables) == 0 ? 1 : 0}"
   function_name    = "${var.function_name}"
   description      = "${var.description}"
   role             = "${aws_iam_role.lambda.arn}"
@@ -80,7 +80,7 @@ resource "aws_lambda_function" "function_noenv" {
 # VPC Lambda / empty environment
 
 resource "aws_lambda_function" "function_vpc_noenv" {
-  count            = "${length(var.subnet_ids) != 0 && length(var.env_variables) == 0 ? 1 : 0}"
+  count            = "${var.count == 1 && length(var.subnet_ids) != 0 && length(var.env_variables) == 0 ? 1 : 0}"
   function_name    = "${var.function_name}"
   description      = "${var.description}"
   role             = "${aws_iam_role.lambda.arn}"

--- a/vars.tf
+++ b/vars.tf
@@ -72,6 +72,9 @@ variable "publish" {
   description = "Whether to publish creation/change as new Lambda Function Version"
   default     = true
 }
+variable "count" {
+  default = 1
+}
 
 ###############################################################################
 # Internal variables


### PR DESCRIPTION
We found ourselves making use of a module that uses this module and sometimes we don't want to create a lambda function.
After adding support of the _count_ variable in this module, now we  can toggle the creation of lambda functions when it's used.