### PR TITLE
Add new node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "lambda" {
 
 - nodejs4.3
 - nodejs6.10
+- nodejs8.10
 - python2.7
 - python3.6
 

--- a/vars.tf
+++ b/vars.tf
@@ -82,6 +82,7 @@ variable "supported_runtimes" {
   default     = [
     "nodejs4.3",
     "nodejs6.10",
+    "nodejs8.10",
     "python2.7",
     "python3.6"
   ]


### PR DESCRIPTION
AWS dropped the support to old Node versions. When this lambda is
created, the following error is thrown:

_* aws_lambda_function.function_noenv: Error creating Lambda function:
InvalidParameterValueException: The runtime parameter of nodejs6.10
is no longer supported for creating or updating AWS Lambda functions.
We recommend you use the new runtime (nodejs8.10) while creating
or updating functions._

The code of this PR was already bundled in this release: https://github.com/door2door-io/d2d-terraform-lambda/releases/tag/v0.0.4