### PR TITLE
Update to terraform v0.12

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -3,9 +3,9 @@
 
 # build deployment package
 resource "null_resource" "lambda_build" {
-  count    = "${var.source_code_path != "" ? 1 : 0}"
+  count = var.source_code_path != "" ? 1 : 0
   triggers = {
-    always_run = "${uuid()}"
+    always_run = uuid()
   }
   provisioner "local-exec" {
     command = "${path.module}/package.sh ${local.runtime} ${var.source_code_path} ${local.function_build_path}"
@@ -14,9 +14,10 @@ resource "null_resource" "lambda_build" {
 
 # create zip archive from build folder to deploy
 data "archive_file" "lambda_deploy_build" {
-  count       = "${var.source_code_path != "" ? 1 : 0}"
+  count       = var.source_code_path != "" ? 1 : 0
   type        = "zip"
-  source_dir  = "${local.function_build_path}"
+  source_dir  = local.function_build_path
   output_path = "${local.tmp_base_path}/deploy-${local.function_name_hash}.zip"
-  depends_on  = ["null_resource.lambda_build"]
+  depends_on  = [null_resource.lambda_build]
 }
+

--- a/main.tf
+++ b/main.tf
@@ -2,103 +2,125 @@
 # non-VPC Lambda
 
 resource "aws_lambda_function" "function" {
-  count            = "${length(var.subnet_ids) == 0 && length(var.env_variables) > 0 ? 1 : 0}"
-  function_name    = "${var.function_name}"
-  description      = "${var.description}"
-  role             = "${aws_iam_role.lambda.arn}"
-  handler          = "${var.handler}"
-  runtime          = "${local.runtime}"
-  timeout          = "${var.timeout}"
-  memory_size      = "${var.memory_size}"
-  filename         = "${local.deploy_archive_file}"
-  source_code_hash = "${local.deploy_archive_hash}"
-  environment      = { variables = "${var.env_variables}" }
-  publish          = "${var.publish}"
-  tags             = "${merge(var.tags, map("Name", var.function_name))}"
+  count            = length(var.subnet_ids) == 0 && length(var.env_variables) > 0 ? 1 : 0
+  function_name    = var.function_name
+  description      = var.description
+  role             = aws_iam_role.lambda.arn
+  handler          = var.handler
+  runtime          = local.runtime
+  timeout          = var.timeout
+  memory_size      = var.memory_size
+  filename         = local.deploy_archive_file
+  source_code_hash = local.deploy_archive_hash
+  environment {
+    variables = var.env_variables
+  }
+  publish = var.publish
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.function_name
+    },
+  )
   lifecycle {
     # Avoid triggering code updates when temp path changes
     # because of different Terraform execution environments
-    ignore_changes = ["filename"]
+    ignore_changes = [filename]
   }
 }
-
 
 ###############################################################################
 # VPC Lambda
 
 resource "aws_lambda_function" "function_vpc" {
-  count            = "${length(var.subnet_ids) != 0 && length(var.env_variables) > 0 ? 1 : 0}"
-  function_name    = "${var.function_name}"
-  description      = "${var.description}"
-  role             = "${aws_iam_role.lambda.arn}"
-  handler          = "${var.handler}"
-  runtime          = "${local.runtime}"
-  timeout          = "${var.timeout}"
-  memory_size      = "${var.memory_size}"
-  filename         = "${local.deploy_archive_file}"
-  source_code_hash = "${local.deploy_archive_hash}"
-  environment      = { variables = "${var.env_variables}" }
-  publish          = "${var.publish}"
-  tags             = "${merge(var.tags, map("Name", var.function_name))}"
+  count            = length(var.subnet_ids) != 0 && length(var.env_variables) > 0 ? 1 : 0
+  function_name    = var.function_name
+  description      = var.description
+  role             = aws_iam_role.lambda.arn
+  handler          = var.handler
+  runtime          = local.runtime
+  timeout          = var.timeout
+  memory_size      = var.memory_size
+  filename         = local.deploy_archive_file
+  source_code_hash = local.deploy_archive_hash
+  environment {
+    variables = var.env_variables
+  }
+  publish = var.publish
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.function_name
+    },
+  )
   vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${var.security_group_ids}"]
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
   }
   lifecycle {
     # Avoid triggering code updates when temp path changes
     # because of different Terraform execution environments
-    ignore_changes = ["filename"]
+    ignore_changes = [filename]
   }
 }
-
 
 ###############################################################################
 # non-VPC Lambda / empty environment
 
 resource "aws_lambda_function" "function_noenv" {
-  count            = "${length(var.subnet_ids) == 0 && length(var.env_variables) == 0 ? 1 : 0}"
-  function_name    = "${var.function_name}"
-  description      = "${var.description}"
-  role             = "${aws_iam_role.lambda.arn}"
-  handler          = "${var.handler}"
-  runtime          = "${local.runtime}"
-  timeout          = "${var.timeout}"
-  memory_size      = "${var.memory_size}"
-  filename         = "${local.deploy_archive_file}"
-  source_code_hash = "${local.deploy_archive_hash}"
-  publish          = "${var.publish}"
-  tags             = "${merge(var.tags, map("Name", var.function_name))}"
+  count            = length(var.subnet_ids) == 0 && length(var.env_variables) == 0 ? 1 : 0
+  function_name    = var.function_name
+  description      = var.description
+  role             = aws_iam_role.lambda.arn
+  handler          = var.handler
+  runtime          = local.runtime
+  timeout          = var.timeout
+  memory_size      = var.memory_size
+  filename         = local.deploy_archive_file
+  source_code_hash = local.deploy_archive_hash
+  publish          = var.publish
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.function_name
+    },
+  )
   lifecycle {
     # Avoid triggering code updates when temp path changes
     # because of different Terraform execution environments
-    ignore_changes = ["filename"]
+    ignore_changes = [filename]
   }
 }
-
 
 ###############################################################################
 # VPC Lambda / empty environment
 
 resource "aws_lambda_function" "function_vpc_noenv" {
-  count            = "${length(var.subnet_ids) != 0 && length(var.env_variables) == 0 ? 1 : 0}"
-  function_name    = "${var.function_name}"
-  description      = "${var.description}"
-  role             = "${aws_iam_role.lambda.arn}"
-  handler          = "${var.handler}"
-  runtime          = "${local.runtime}"
-  timeout          = "${var.timeout}"
-  memory_size      = "${var.memory_size}"
-  filename         = "${local.deploy_archive_file}"
-  source_code_hash = "${local.deploy_archive_hash}"
-  publish          = "${var.publish}"
-  tags             = "${merge(var.tags, map("Name", var.function_name))}"
+  count            = length(var.subnet_ids) != 0 && length(var.env_variables) == 0 ? 1 : 0
+  function_name    = var.function_name
+  description      = var.description
+  role             = aws_iam_role.lambda.arn
+  handler          = var.handler
+  runtime          = local.runtime
+  timeout          = var.timeout
+  memory_size      = var.memory_size
+  filename         = local.deploy_archive_file
+  source_code_hash = local.deploy_archive_hash
+  publish          = var.publish
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.function_name
+    },
+  )
   vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${var.security_group_ids}"]
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
   }
   lifecycle {
     # Avoid triggering code updates when temp path changes
     # because of different Terraform execution environments
-    ignore_changes = ["filename"]
+    ignore_changes = [filename]
   }
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,61 +1,65 @@
 output "lambda_arn" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.arn),
     join(",", aws_lambda_function.function_vpc.*.arn),
     join(",", aws_lambda_function.function_noenv.*.arn),
-    join(",", aws_lambda_function.function_vpc_noenv.*.arn)
-  )}"
+    join(",", aws_lambda_function.function_vpc_noenv.*.arn),
+  )
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.lambda.arn}"
+  value = aws_iam_role.lambda.arn
 }
 
 output "role_name" {
-  value = "${aws_iam_role.lambda.name}"
+  value = aws_iam_role.lambda.name
 }
 
 output "qualified_arn" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.qualified_arn),
     join(",", aws_lambda_function.function_vpc.*.qualified_arn),
     join(",", aws_lambda_function.function_noenv.*.qualified_arn),
-    join(",", aws_lambda_function.function_vpc_noenv.*.qualified_arn)
-  )}"
+    join(",", aws_lambda_function.function_vpc_noenv.*.qualified_arn),
+  )
 }
 
 output "invoke_arn" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.invoke_arn),
     join(",", aws_lambda_function.function_vpc.*.invoke_arn),
     join(",", aws_lambda_function.function_noenv.*.invoke_arn),
-    join(",", aws_lambda_function.function_vpc_noenv.*.invoke_arn)
-  )}"
+    join(",", aws_lambda_function.function_vpc_noenv.*.invoke_arn),
+  )
 }
 
 output "version" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.version),
     join(",", aws_lambda_function.function_vpc.*.version),
     join(",", aws_lambda_function.function_noenv.*.version),
-    join(",", aws_lambda_function.function_vpc_noenv.*.version)
-  )}"
+    join(",", aws_lambda_function.function_vpc_noenv.*.version),
+  )
 }
 
 output "last_modified" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.last_modified),
     join(",", aws_lambda_function.function_vpc.*.last_modified),
     join(",", aws_lambda_function.function_noenv.*.last_modified),
-    join(",", aws_lambda_function.function_vpc_noenv.*.last_modified)
-  )}"
+    join(",", aws_lambda_function.function_vpc_noenv.*.last_modified),
+  )
 }
 
 output "source_code_hash" {
-  value = "${coalesce(
+  value = coalesce(
     join(",", aws_lambda_function.function.*.source_code_hash),
     join(",", aws_lambda_function.function_vpc.*.source_code_hash),
     join(",", aws_lambda_function.function_noenv.*.source_code_hash),
-    join(",", aws_lambda_function.function_vpc_noenv.*.source_code_hash)
-  )}"
+    join(
+      ",",
+      aws_lambda_function.function_vpc_noenv.*.source_code_hash,
+    ),
+  )
 }
+

--- a/role.tf
+++ b/role.tf
@@ -3,33 +3,34 @@ data "aws_iam_policy_document" "lambda_assume" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = [
         "lambda.amazonaws.com",
-        "edgelambda.amazonaws.com"
+        "edgelambda.amazonaws.com",
       ]
     }
   }
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = "${local.aws_iam_role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume.json}"
+  name               = local.aws_iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_service_role" {
-  role       = "${aws_iam_role.lambda.name}"
-  policy_arn = "${local.lambda_service_role}"
+  role       = aws_iam_role.lambda.name
+  policy_arn = local.lambda_service_role
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_attach_policies" {
-  count      = "${local.attach_policies_count}"
-  role       = "${aws_iam_role.lambda.name}"
-  policy_arn = "${var.attach_policies[count.index]}"
+  count      = local.attach_policies_count
+  role       = aws_iam_role.lambda.name
+  policy_arn = var.attach_policies[count.index]
 }
 
 resource "aws_iam_role_policy" "lambda_inline_policies" {
-  count  = "${local.inline_policies_count}"
-  role   = "${aws_iam_role.lambda.name}"
-  policy = "${var.inline_policies[count.index]}"
+  count  = local.inline_policies_count
+  role   = aws_iam_role.lambda.name
+  policy = var.inline_policies[count.index]
 }
+

--- a/vars.tf
+++ b/vars.tf
@@ -2,15 +2,17 @@
 # Mandatory input variables
 
 variable "function_name" {
-  type        = "string"
+  type        = string
   description = "Lambda function name"
 }
+
 variable "runtime" {
-  type        = "string"
+  type        = string
   description = "Lambda function runtime"
 }
+
 variable "handler" {
-  type        = "string"
+  type        = string
   description = "Name of the function that Lambda will call to start running"
 }
 
@@ -18,57 +20,67 @@ variable "handler" {
 # Optional input variables
 
 variable "source_code_path" {
-  type        = "string"
+  type        = string
   description = "Path to function's source code to manage deployment"
   default     = ""
 }
+
 variable "description" {
-  type        = "string"
+  type        = string
   description = "Lambda function description"
   default     = "A Lambda function managed by Terraform"
 }
+
 variable "timeout" {
-  type        = "string"
+  type        = string
   description = "Function execution time in seconds after which Lambda terminates the function"
   default     = "10"
 }
+
 variable "memory_size" {
-  type        = "string"
+  type        = string
   description = "Amount of memory in MB allocated to the Lambda function"
   default     = "128"
 }
+
 variable "subnet_ids" {
-  type        = "list"
+  type        = list(string)
   description = "List of subnet IDs to run the Lambda in the private VPC they belong to"
   default     = []
 }
+
 variable "security_group_ids" {
-  type        = "list"
+  type        = list(string)
   description = "List of security group IDs to attach to the Lambda"
   default     = []
 }
+
 variable "env_variables" {
-  type        = "map"
+  type        = map(string)
   description = "Map of environment variables passed to Lambda function"
   default     = {}
 }
+
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Map of tags to add to the Lambda"
   default     = {}
 }
+
 variable "attach_policies" {
-  type        = "list"
+  type        = list(string)
   description = "List of IAM policies to attach to the Lambda role"
   default     = []
 }
+
 variable "inline_policies" {
-  type        = "list"
+  type        = list(string)
   description = "List of inline json policy documents to include in the Lambda role"
   default     = []
 }
+
 variable "publish" {
-  type        = "string"
+  type        = string
   description = "Whether to publish creation/change as new Lambda Function Version"
   default     = true
 }
@@ -77,22 +89,22 @@ variable "publish" {
 # Internal variables
 
 variable "supported_runtimes" {
-  type        = "list"
+  type        = list(string)
   description = "List of supported runtimes, used to validate input variable 'runtime'"
-  default     = [
+  default = [
     "nodejs4.3",
     "nodejs6.10",
     "nodejs8.10",
     "nodejs10.x",
     "python2.7",
-    "python3.6"
+    "python3.6",
   ]
 }
 
 variable "lambda_service_role" {
-  type        = "map"
+  type        = map(string)
   description = "Service roles assigned to VPC and non-VPC Lambdas"
-  default     = {
+  default = {
     "basic" = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
     "vpc"   = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   }
@@ -100,24 +112,42 @@ variable "lambda_service_role" {
 
 locals {
   # Select right service role depending on VPC or non-VPC setup
-  lambda_service_role = "${length(var.subnet_ids) == 0 ? var.lambda_service_role["basic"] : var.lambda_service_role["vpc"]}"
+  lambda_service_role = length(var.subnet_ids) == 0 ? var.lambda_service_role["basic"] : var.lambda_service_role["vpc"]
+
   # Validate runtime input
-  runtime = "${lookup(zipmap(var.supported_runtimes, var.supported_runtimes), var.runtime)}"
+  runtime = zipmap(var.supported_runtimes, var.supported_runtimes)[var.runtime]
+
   # Prefix Lambda role name with 'lambda-'
-  aws_iam_role_name = "${format("lambda-%s", var.function_name)}"
+  aws_iam_role_name = format("lambda-%s", var.function_name)
+
   # Compute count of attach_policies and inline_policies here to workaround TF issue
   # https://github.com/hashicorp/terraform/issues/12570#issuecomment-359886242
-  attach_policies_count = "${length(var.attach_policies)}"
-  inline_policies_count = "${length(var.inline_policies)}"
+  attach_policies_count = length(var.attach_policies)
+  inline_policies_count = length(var.inline_policies)
+
   # empty function archive file
   empty_function = "${path.module}/empty-function.zip"
+
   # build base path
   tmp_base_path = "${path.root}/.tmp"
+
   # get a common hash for this function
-  function_name_hash = "${sha256(var.function_name)}"
+  function_name_hash = sha256(var.function_name)
+
   # build output folder
   function_build_path = "${local.tmp_base_path}/build-${local.function_name_hash}"
+
   # Get the right archive file and hash to deploy
-  deploy_archive_file = "${coalesce(join(",", data.archive_file.lambda_deploy_build.*.output_path), local.empty_function)}"
-  deploy_archive_hash = "${coalesce(join(",", data.archive_file.lambda_deploy_build.*.output_base64sha256), base64sha256(file(local.empty_function)))}"
+  deploy_archive_file = coalesce(
+    join(",", data.archive_file.lambda_deploy_build.*.output_path),
+    local.empty_function,
+  )
+  deploy_archive_hash = coalesce(
+    join(
+      ",",
+      data.archive_file.lambda_deploy_build.*.output_base64sha256,
+    ),
+    base64sha256(filesha256(local.empty_function)),
+  )
 }
+


### PR DESCRIPTION
# Issue number(s)

# Description

Updates the lambda module for the terraform's v0.12 syntax.  As part of the process i created  new semantic version (https://github.com/door2door-io/d2d-terraform-lambda/releases/tag/v0.1.0) so we can keep updating both versions if needed.

All the changes here were generate by terraform's official upgrade script, except for https://github.com/door2door-io/d2d-terraform-lambda/compare/v0.12?expand=1#diff-d602f1972bf5180b01721738bfa93dbeR150 where I manually changed the function to load files since the previous one was failing.

# Before merge

List any actions that should be taken before merging and deploying, if there are any outstanding.

# Checklist

I have:

- [ ] Crafted commit messages according to https://chris.beams.io/posts/git-commit/
- [ ] If the open-source dependencies have been changed or updated, I have checked they use an [appropriate license](https://allyapp.atlassian.net/wiki/spaces/TECH/pages/805470209/Open+Source+Licenses) and updated the [open-source dependencies list](https://allyapp.atlassian.net/wiki/spaces/TECH/pages/574914796/Open-Source+dependencies)
